### PR TITLE
forcing control type="text" on input

### DIFF
--- a/src/Forms/Controls/CurrencyInput.php
+++ b/src/Forms/Controls/CurrencyInput.php
@@ -116,9 +116,9 @@ class CurrencyInput extends TextInput
 	 */
 	public function getControl(): Html
 	{
-		return parent::getControl()->addAttributes([
-			static::$defaultDataAttributeName => $this->getFormat(),
-		]);
+		return parent::getControl()
+			->addAttributes([static::$defaultDataAttributeName => $this->getFormat()])
+			->setAttribute('type', 'text');
 	}
 
 	/**


### PR DESCRIPTION
Pri pouziti npr addRule(Form::INTEGER,...) sa zmeni typ input tagu na number, co znefunkcni javascript.
Autonumeric nepodporuje numeric typ:

```
Note : the number type is not supported simply because autoNumeric formats numbers as strings (ie. '123.456.789,00 &#8364;') that this input type does not allow.
```
