### PR TITLE
FIX: multiple currency languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,4 +52,4 @@ And in latte:
 ```
 
 
-To turn on autocomplete in IDE, add `@method CurrencyInput addCurrency($name, $label = null, $language = 'cs')` to your base form.
+To turn on autocomplete in IDE, add `@method CurrencyInput addCurrency($name, $label = null, $currency = null, $language = null)` to your base form.

--- a/src/Forms/Controls/CurrencyInput.php
+++ b/src/Forms/Controls/CurrencyInput.php
@@ -65,10 +65,11 @@ class CurrencyInput extends TextInput
 		],
 	];
 
-	public static function addCurrency(Container $container, $name, $label = null, $currency = null)
+	public static function addCurrency(Container $container, $name, $label = null, $currency = null, $language = null)
 	{
 		$component = (new self($label));
 		$component->setOption('currency', $currency);
+		$component->setOption('language', $language);
 
 		$container->addComponent($component, $name);
 
@@ -83,7 +84,7 @@ class CurrencyInput extends TextInput
 
 	public function getFormat()
 	{
-		$options = static::$formats[static::$defaultLanguage];
+		$options =  static::$formats[$this->getOption('language')] ?? static::$formats[static::$defaultLanguage];
 
 		switch ($options['currencyExpression']) {
 			case 'symbol':


### PR DESCRIPTION
In case of currency inputs with multiple languages only $format options for $defaultLanguage were used.

For example: Its not possible to add an option decimalPlaces for CURRENCY_EUR if $defaultLanguage is LANGUAGE_CS. 

REASON: Its not possible to change $format options because getFormat() always returns $format options for $defaultLanguage
SOLUTION: added language option to input -> getFormat() is using this option